### PR TITLE
add go.mod and ignore TLS errors.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,17 @@
+module gospray
+
+go 1.20
+
+require (
+        github.com/go-ldap/ldap/v3 v3.4.6
+        github.com/wunderwuzzi23/wuzziutils v0.0.0-20200305182538-a2d7c8718619
+)
+
+require (
+        github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect
+        github.com/go-asn1-ber/asn1-ber v1.5.5 // indirect
+        github.com/google/uuid v1.3.1 // indirect
+        golang.org/x/crypto v0.13.0 // indirect
+        gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
+        gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df // indirect
+)

--- a/gospray.go
+++ b/gospray.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/wunderwuzzi23/wuzziutils/mailutil"
-	ldap "gopkg.in/ldap.v3"
+	ldap "github.com/go-ldap/ldap/v3"
 )
 
 type configuration struct {
@@ -127,6 +127,7 @@ func main() {
 		certs.AppendCertsFromPEM(pemCA)
 
 		config.tlsConfig = &tls.Config{
+			InsecureSkipVerify: true,
 			RootCAs: certs}
 	}
 


### PR DESCRIPTION
Creates usage for new Golang and ignores TLS errors.